### PR TITLE
Use spread syntax on index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 require('./main.scss');
 
-const Elm = require('./Main.elm');
+const { Elm } = require('./Main.elm');
 const mountNode = document.getElementById('main');
 
-const app = Elm.Elm.Main.init({
+Elm.Main.init({
   node: document.getElementById('main')
 });


### PR DESCRIPTION
I feel that the part `Elm.Elm.Main.init` is strange.

If you use `spread syntax`, you can write naturally as` Elm.Main.init`.